### PR TITLE
Add Huffman solutions for C and Rust

### DIFF
--- a/Solutions/challenge-huffman.md
+++ b/Solutions/challenge-huffman.md
@@ -36,3 +36,5 @@ The shared solutions:
 | 28 | [zippy](https://github.com/ravil-gasanov/zippy) | Python | [Ravil Gasanov](https://github.com/ravil-gasanov) |
 | 29 | [huffman-compressor-cpp](https://github.com/r-harsh-r/huffman-encoder-cpp-optimised) | C++ | [Harsh R](https://github.com/r-harsh-r) |
 | 30 | [challenge-huffman](https://github.com/blissful-coder/CodingChallenges/tree/main/challenge-huffman) | C++ | [Anurag Negi](https://github.com/blissful-coder) |
+| 31 | [huffman-encoder-c](https://github.com/yannvanhalewyn/coding-challenges/tree/main/huffman-encoder-c) | C | [Yann Vanhalewyn](https://github.com/yannvanhalewyn) |
+| 32 | [huffman-encoder-rust](https://github.com/yannvanhalewyn/coding-challenges/tree/main/huffman-encoder-rust) | Rust | [Yann Vanhalewyn](https://github.com/yannvanhalewyn) |


### PR DESCRIPTION
Adds two solutions for Huffman encoding: one in C and one in Rust.

---

BTW: I love the approach of Coding Challenges! The challenges themselves are top tier and it's awesome that they're language agnostic while still providing enough structure and resources to build and learn. I've had fun learning, thank you!