### PR TITLE
Add Rust wc-tool implementation (ccwc)

### DIFF
--- a/Solutions/challenge-wc.md
+++ b/Solutions/challenge-wc.md
@@ -156,3 +156,4 @@ The shared solutions:
 | 147 | [ccwc](https://github.com/dphogit/ccwc/tree/main) | C | [dphogit](https://github.com/dphogit)
 | 148 | [challenge-wc](https://github.com/blissful-coder/CodingChallenges/tree/main/challenge-wc) | C++ | [Anurag Negi](https://github.com/blissful-coder)
 | 149 | [wc-3-prog-paradigms](https://github.com/atherio-danp/coding-challanges/tree/main/wc-tool) | C# | [Dan Patrascu-Baba](https://github.com/atherio-danp) 
+| 150 | [wc-tool-rust](https://github.com/ihaagrawal/wc-tool-rust) | Rust | [Iha Agrawal](https://github.com/ihaagrawal) 


### PR DESCRIPTION
Added my Rust implementation of the wc tool.

Supports:
- -c (bytes)
- -l (lines)
- -w (words)
- -m (characters)
- Default behavior (lines, words, bytes)

Repo: https://github.com/ihaagrawal/wc-tool-rust